### PR TITLE
allow psr/log ^2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
   },
   "require": {
     "php": ">=8.0",
-    "psr/log": "^1.1",
+    "psr/log": "^1.1|^2.0",
     "ramsey/uuid": "^3.0|^4.0",
     "ocramius/proxy-manager": "^2.11"
   },


### PR DESCRIPTION
Only psr/log ^2.0 can be allowed due to restrictions in php-coveralls/php-coveralls (https://github.com/php-coveralls/php-coveralls/pull/321).