### PR TITLE
Adds gitattributes to exclude unnecessary files from production.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+.github/                    export-ignore
+.gitattributes              export-ignore
+.gitignore                  export-ignore
+.php-cs-fixer.dist.php      export-ignore
+behat.yml                   export-ignore
+docker-compose.yml          export-ignore
+ecotone_small.png           export-ignore
+monorepo-builder.php        export-ignore
+phpstan.neon                export-ignore
+phpunit.xml                 export-ignore

--- a/packages/Amqp/.gitattributes
+++ b/packages/Amqp/.gitattributes
@@ -1,0 +1,6 @@
+tests/          export-ignore
+.gitattributes  export-ignore
+.gitignore      export-ignore
+behat.yaml      export-ignore
+phpstan.neon    export-ignore
+phpunit.xml     export-ignore

--- a/packages/Core/.gitattributes
+++ b/packages/Core/.gitattributes
@@ -1,0 +1,7 @@
+tests/          export-ignore
+.gitattributes  export-ignore
+.gitignore      export-ignore
+behat.yaml      export-ignore
+phpstan.neon    export-ignore
+phpunit.xml     export-ignore
+rector.php      export-ignore

--- a/packages/Dbal/.gitattributes
+++ b/packages/Dbal/.gitattributes
@@ -1,0 +1,7 @@
+tests/          export-ignore
+.coveralls.yml  export-ignore
+.gitattributes  export-ignore
+.gitignore      export-ignore
+behat.yaml      export-ignore
+phpstan.neon    export-ignore
+phpunit.xml     export-ignore

--- a/packages/Enqueue/.gitattributes
+++ b/packages/Enqueue/.gitattributes
@@ -1,0 +1,8 @@
+tests/          export-ignore
+.coveralls.yml  export-ignore
+.gitattributes  export-ignore
+.gitignore      export-ignore
+.travis.yml     export-ignore
+behat.yaml      export-ignore
+phpstan.neon    export-ignore
+phpunit.xml     export-ignore

--- a/packages/EventSourcing/.gitattributes
+++ b/packages/EventSourcing/.gitattributes
@@ -1,0 +1,7 @@
+tests/          export-ignore
+.coveralls.yml  export-ignore
+.gitattributes  export-ignore
+.gitignore      export-ignore
+behat.yaml      export-ignore
+phpstan.neon    export-ignore
+phpunit.xml     export-ignore

--- a/packages/JmsConverter/.gitattributes
+++ b/packages/JmsConverter/.gitattributes
@@ -1,0 +1,5 @@
+tests/          export-ignore
+.gitattributes  export-ignore
+behat.yaml      export-ignore
+phpstan.neon    export-ignore
+phpunit.xml     export-ignore

--- a/packages/Laravel/.gitattributes
+++ b/packages/Laravel/.gitattributes
@@ -1,0 +1,5 @@
+tests/              export-ignore
+.gitattributes      export-ignore
+behat.yaml          export-ignore
+phpstan.neon        export-ignore
+phpunit.xml.dist    export-ignore

--- a/packages/Symfony/.gitattributes
+++ b/packages/Symfony/.gitattributes
@@ -1,0 +1,5 @@
+tests/          export-ignore
+.gitattributes  export-ignore
+behat.yaml      export-ignore
+phpstan.neon    export-ignore
+phpunit.xml     export-ignore


### PR DESCRIPTION
This pull request adds `.gitattributes` files to the packages to ensure certain files are never pulled by composer whn installing the packages. This keeps them nice and tidy in production code bases.

On another note, we should probably look at removing some of the build files from packages and moving them to the root monorepo.